### PR TITLE
dep. update 06/30/25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,11 +1524,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
-      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query author:app/dependabot --interactive --verbose.

It combines the following PRs:

- Bump prettier from 3.6.0 to 3.6.2 (#17) @app/dependabot
- Bump @rollup/plugin-typescript from 12.1.3 to 12.1.4 (#16) @app/dependabot
- Bump rollup from 4.44.0 to 4.44.1 (#15) @app/dependabot
- Bump @types/node from 24.0.3 to 24.0.7 (#14) @app/dependabot

## Related Issues:

- Closes #17
- Closes #16
- Closes #15
- Closes #14
