### PR TITLE
dep. update 07/07/25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -923,9 +923,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
-      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~7.8.0"


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query author:app/dependabot --interactive --verbose.

It combines the following PRs:

- Bump @types/node from 24.0.7 to 24.0.10 (#20) @app/dependabot
- Bump rollup from 4.44.1 to 4.44.2 (#19) @app/dependabot

## Related Issues:

- Closes #20
- Closes #19
