### PR TITLE
dep. update 07/28/25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -947,9 +947,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
-      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query author:app/dependabot --interactive --verbose.

It combines the following PRs:

- Bump @types/node from 24.0.15 to 24.1.0 (#26) @app/dependabot
- Bump rollup from 4.45.1 to 4.46.0 (#25) @app/dependabot

## Related Issues:

- Closes #26
- Closes #25
