### PR TITLE
dep. update 10/06/25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1972,9 +1972,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query author:app/dependabot.

It combines the following PRs:

- Bump typescript from 5.9.2 to 5.9.3 (#45) @app/dependabot
- Bump @rollup/plugin-node-resolve from 16.0.1 to 16.0.2 (#44) @app/dependabot
- Bump rollup from 4.52.3 to 4.52.4 (#43) @app/dependabot
- Bump @types/node from 24.5.2 to 24.6.2 (#42) @app/dependabot

## Related Issues:

- Closes #45
- Closes #44
- Closes #43
- Closes #42
